### PR TITLE
Changed shebang in `start.sh`

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 if test -f .flaskenv; then
   export $(cat .flaskenv | xargs)
 else


### PR DESCRIPTION
Have changed shebang from `#!/bin/env` to `#!/usr/bin/env`. On certain Docker images(like Debian Buster Slim), `#!/bin/env` isn't set.