### PR TITLE
Updated `flask run` command in `start.sh` file

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,4 +12,4 @@ then
 	(pkill -f check_changes.py)
 	(python3 check_changes.py &)
 fi
-FLASK_DEBUG=1 flask run
+FLASK_DEBUG=1 flask run --host=0.0.0.0


### PR DESCRIPTION
Changed `flask run` command by adding the `--host=0.0.0.0` in order to bind to all interfaces. Previously, it would bind to localhost(127.0.0.1) which would cause issues with connecting to the service when containerised. For detailed information on why this happens, refer to this [link](https://pythonspeed.com/articles/docker-connection-refused/).