### PR TITLE
add integration tests for pocket importer

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install -r requirements-tests.txt
     - name: Run tests
       run: |
         pytest tests/

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from shutil import rmtree
 
 import frontmatter
+from flask import current_app
 
-from archivy.config import Config
 
-DIRNAME = Config.APP_PATH + "/data/"
+# FIXME: ugly hack to make sure the app path is evaluated at the right time
+def get_data_dir():
+    return os.path.join(current_app.config['APP_PATH'], "data")
 
 # struct to create tree like file-structure
 
@@ -32,7 +34,8 @@ def valid_filename(name):
 def get_items(collections=[], path="", structured=True):
     datacont = Directory("root") if structured else []
     if structured:
-        for filename in glob.glob(DIRNAME + path + "**/*", recursive=True):
+        for filename in glob.glob(get_data_dir() + path + "**/*",
+                                  recursive=True):
             paths = filename.split("/data/")[1].split("/")
             data = frontmatter.load(
                 filename) if filename.endswith(".md") else None
@@ -49,7 +52,8 @@ def get_items(collections=[], path="", structured=True):
                         current_dir.child_dirs[segment] = Directory(segment)
                     current_dir = current_dir.child_dirs[segment]
     else:
-        for filename in glob.glob(DIRNAME + path + "**/*.md", recursive=True):
+        for filename in glob.glob(get_data_dir() + path + "**/*.md",
+                                  recursive=True):
             data = frontmatter.load(filename)
             if len(collections) == 0 or \
                     any([collection == data["type"]
@@ -61,7 +65,7 @@ def get_items(collections=[], path="", structured=True):
 
 def create(contents, title, path="", needs_to_open=False):
     path_to_md_file = os.path.join(
-        DIRNAME, path, "{}.md".format(valid_filename(title)))
+        get_data_dir(), path, "{}.md".format(valid_filename(title)))
     with open(path_to_md_file, "w") as file:
         file.write(contents)
 
@@ -71,19 +75,20 @@ def create(contents, title, path="", needs_to_open=False):
 
 
 def get_item(dataobj_id):
-    file = glob.glob(f"{DIRNAME}**/{dataobj_id}-*.md", recursive=True)[0]
+    file = glob.glob(f"{get_data_dir()}**/{dataobj_id}-*.md",
+                     recursive=True)[0]
     data = frontmatter.load(file)
     data["fullpath"] = file
     return data
 
 
 def delete_item(id):
-    file = glob.glob(f"{DIRNAME}**/{id}-*.md", recursive=True)[0]
+    file = glob.glob(f"{get_data_dir()}**/{id}-*.md", recursive=True)[0]
     os.remove(file)
 
 
 def get_dirs():
-    dirnames = glob.glob(DIRNAME + "**/*", recursive=True)
+    dirnames = glob.glob(get_data_dir() + "**/*", recursive=True)
     dirnames = [name.split("/data/")[1]
                 for name in dirnames if not name.endswith(".md")]
     dirnames.append("not classified")
@@ -93,12 +98,12 @@ def get_dirs():
 def create_dir(name):
     sanitized_name = "/".join([valid_filename(pathname)
                                for pathname in name.split("/")])
-    Path(DIRNAME + sanitized_name).mkdir(parents=True, exist_ok=True)
+    Path(get_data_dir() + sanitized_name).mkdir(parents=True, exist_ok=True)
 
 
 def delete_dir(name):
     try:
-        rmtree(DIRNAME + name)
+        rmtree(get_data_dir() + name)
         return True
     except FileNotFoundError:
         return False

--- a/archivy/data.py
+++ b/archivy/data.py
@@ -1,7 +1,7 @@
-import os
-import re
 import glob
+import os
 import platform
+import re
 import subprocess
 from pathlib import Path
 from shutil import rmtree

--- a/archivy/extensions.py
+++ b/archivy/extensions.py
@@ -1,21 +1,35 @@
+import os
+
+from flask import current_app, g
 from tinydb import TinyDB, Query, operations
 from elasticsearch import Elasticsearch
 from archivy.config import Config
 
 
-DB = TinyDB(Config.APP_PATH + "/db.json")
+def get_db():
+    if 'db' not in g:
+        g.db = TinyDB(
+            os.path.join(
+                current_app.config['APP_PATH'],
+                'db.json'
+            )
+        )
+
+    return g.db
 
 
 def get_max_id():
-    max_id = DB.search(Query().name == "max_id")
+    db = get_db()
+    max_id = db.search(Query().name == "max_id")
     if not max_id:
-        DB.insert({"name": "max_id", "val": 0})
+        db.insert({"name": "max_id", "val": 0})
         return 0
     return max_id[0]["val"]
 
 
 def set_max_id(val):
-    DB.update(operations.set("val", val), Query().name == "max_id")
+    db = get_db()
+    db.update(operations.set("val", val), Query().name == "max_id")
 
 
 def elastic_client():

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -1,16 +1,17 @@
 import datetime
 from urllib.parse import urljoin
 
-import validators
-import requests
-import html2text
 import frontmatter
+import html2text
+import requests
+import validators
 from bs4 import BeautifulSoup
+from flask import current_app
 
 from archivy import extensions
-from archivy.search import add_to_index
 from archivy.data import create
 from archivy.config import Config
+from archivy.search import add_to_index
 
 
 class DataObj:

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -10,7 +10,6 @@ from flask import current_app
 
 from archivy import extensions
 from archivy.data import create
-from archivy.config import Config
 from archivy.search import add_to_index
 
 
@@ -121,7 +120,7 @@ class DataObj:
                                 path=self.path,
                                 needs_to_open=self.type == "note")
 
-            add_to_index(Config.INDEX_NAME, self)
+            add_to_index(current_app.config['INDEX_NAME'], self)
             return self.id
         return False
 

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -185,6 +185,9 @@ def parse_pocket():
             Query().type == "pocket_key")
         flash(f"{resp.json()['username']} Signed in!")
 
+    # update pocket dictionary
+    pocket = db.search(Query().type == "pocket_key")[0]
+
     pocket_data = {
         "consumer_key": pocket["consumer_key"],
         "access_token": pocket["access_token"],

--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,11 @@ def mocked_responses():
 
 @pytest.fixture()
 def note_fixture(test_app):
-    datapoints = {"type": "note", "title": "Test Note", "desc": "A note to test model functionality", "tags": ["testing", "archivy"], "path": ""}
+    datapoints = {
+        "type": "note", "title": "Test Note",
+        "desc": "A note to test model functionality",
+        "tags": ["testing", "archivy"], "path": ""
+    }
 
     with test_app.app_context():
         note = DataObj(**datapoints)

--- a/conftest.py
+++ b/conftest.py
@@ -33,7 +33,7 @@ def test_app():
 
 @pytest.fixture
 def client(test_app):
-    with app.test_client() as client:
+    with test_app.test_client() as client:
         yield client
 
 
@@ -43,10 +43,11 @@ def mocked_responses():
         yield rsps
 
 
-@pytest.fixture(scope="session")
-def note_fixture():
+@pytest.fixture()
+def note_fixture(test_app):
     datapoints = {"type": "note", "title": "Test Note", "desc": "A note to test model functionality", "tags": ["testing", "archivy"], "path": ""}
 
-    note = DataObj(**datapoints)
-    note.insert()
+    with test_app.app_context():
+        note = DataObj(**datapoints)
+        note.insert()
     return note

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,31 @@
-import pytest
+import os
+import shutil
+import tempfile
 
+import pytest
+import responses
+
+from archivy import app, config
 from archivy.models import DataObj
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app_dir = tempfile.mkdtemp()
+    app.config['APP_PATH'] = app_dir
+    data_dir = os.path.join(app_dir, "data")
+    os.mkdir(data_dir)
+
+    with app.test_client() as client:
+        yield client
+
+    shutil.rmtree(app_dir)
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
 
 @pytest.fixture(scope="session")
 def note_fixture():

--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,7 @@ def client(test_app):
 @pytest.fixture
 def mocked_responses():
     with responses.RequestsMock() as rsps:
+        rsps.assert_all_requests_are_fired = True
         yield rsps
 
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,4 @@
+pytest==6.0.1
+
+# for mocking out requests HTTP calls
+responses==0.10.16

--- a/tests/integration/test_pocket.py
+++ b/tests/integration/test_pocket.py
@@ -1,0 +1,50 @@
+import responses
+from flask import Flask
+
+from archivy import data
+from archivy.extensions import get_db
+
+
+def test_parse_pocket(test_app, client, mocked_responses):
+    """Test the /pocket endpoint by mocking out the external HTTP calls to the
+    pocket API
+    """
+    with test_app.app_context():
+        db = get_db()
+
+    mocked_responses.add(responses.POST, "https://getpocket.com/v3/get", json={
+        'status': 1, 'complete': 1, 'list': {
+            '3088163616': {
+                'given_url': 'https://example.com', 'status': '0',
+                'resolved_url': 'https://example.com',
+                'excerpt': 'Lorem ipsum', 'is_article': '1',
+            },
+        },
+    })
+
+    mocked_responses.add(responses.GET, "https://example.com/", body="""<html>
+        <head><title>Example</title></head><body><p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit
+        </p></body></html>
+    """)
+
+    mocked_responses.add(
+        responses.POST,
+        "https://getpocket.com/v3/oauth/authorize",
+        json={
+            "access_token": "5678defg-5678-defg-5678-defg56",
+            "username": "test_user"
+        })
+
+    pocket_key = {
+        "type": "pocket_key",
+        "consumer_key": "1234-abcd1234abcd1234abcd1234",
+        "code": "dcba4321-dcba-4321-dcba-4321dc",
+    }
+    db.insert(pocket_key)
+
+    r: Flask.response_class = client.get('/parse_pocket?new=1')
+    assert r.status_code == 302
+
+    dataobjs = data.get_items()
+    assert len(dataobjs.child_files) == 1

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,22 +1,19 @@
 import frontmatter
-import pytest
 
 from archivy.extensions import get_max_id
 
 attributes = ["type", "title", "desc", "tags", "path", "id"]
 
-def test_new_note(note_fixture):
+
+def test_new_note(test_app, note_fixture):
     """
     Check that a new note is correctly saved into the filesystem
     with the right attributes and the right id.
     """
-    max_id = get_max_id()
-    assert note_fixture.id + 1 == max_id
+    with test_app.app_context():
+        max_id = get_max_id()
+        assert note_fixture.id + 1 == max_id
     
     saved_file = frontmatter.load(note_fixture.fullpath)
     for attr in attributes:
         assert getattr(note_fixture, attr) == saved_file[attr]
-
-
-
-


### PR DESCRIPTION
 - [ ] I have not managed to correctly change the `APP_PATH` configuration key in tests, `archivy/data.py` does not retrieve the configuration from the app, but directly from the config module.


## Notes on mocking http calls
I'm using https://pypi.org/project/responses/ for mocking out requests calls in the pocket route. This can be confusing because the test client does not use `requests` (see https://werkzeug.palletsprojects.com/en/1.0.x/test/#werkzeug.test.Client). So, in my test, only the calls to `requests.get` and `requets.post` in the `/pocket` route are mocked. `client.post('/pocket', ...)` makes an actual call to the archivy route.

One possible fix would be to use another test client, wrapping requests, in integration tests.

In any case, feel free to suggest another way to mock external HTTP calls in tests.

