### PR TITLE
Improve testing and add integration test for pocket

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install -r requirements-tests.txt
     - name: Run tests
       run: |
         pytest tests/

--- a/archivy/extensions.py
+++ b/archivy/extensions.py
@@ -1,21 +1,35 @@
+import os
+
+from flask import current_app, g
 from tinydb import TinyDB, Query, operations
 from elasticsearch import Elasticsearch
 from archivy.config import Config
 
 
-DB = TinyDB(Config.APP_PATH + "/db.json")
+def get_db():
+    if 'db' not in g:
+        g.db = TinyDB(
+            os.path.join(
+                current_app.config['APP_PATH'],
+                'db.json'
+            )
+        )
+
+    return g.db
 
 
 def get_max_id():
-    max_id = DB.search(Query().name == "max_id")
+    db = get_db()
+    max_id = db.search(Query().name == "max_id")
     if not max_id:
-        DB.insert({"name": "max_id", "val": 0})
+        db.insert({"name": "max_id", "val": 0})
         return 0
     return max_id[0]["val"]
 
 
 def set_max_id(val):
-    DB.update(operations.set("val", val), Query().name == "max_id")
+    db = get_db()
+    db.update(operations.set("val", val), Query().name == "max_id")
 
 
 def elastic_client():

--- a/archivy/models.py
+++ b/archivy/models.py
@@ -6,11 +6,11 @@ import requests
 import html2text
 import frontmatter
 from bs4 import BeautifulSoup
+from flask import current_app
 
 from archivy import extensions
 from archivy.search import add_to_index
 from archivy.data import create
-from archivy.config import Config
 
 
 class DataObj:
@@ -117,7 +117,7 @@ class DataObj:
                                 path=self.path,
                                 needs_to_open=self.type == "note")
 
-            add_to_index(Config.INDEX_NAME, self)
+            add_to_index(current_app.config['INDEX_NAME'], self)
             return self.id
         return False
 

--- a/archivy/routes.py
+++ b/archivy/routes.py
@@ -185,6 +185,9 @@ def parse_pocket():
             Query().type == "pocket_key")
         flash(f"{resp.json()['username']} Signed in!")
 
+    # update pocket dictionary
+    pocket = db.search(Query().type == "pocket_key")[0]
+
     pocket_data = {
         "consumer_key": pocket["consumer_key"],
         "access_token": pocket["access_token"],

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,70 @@
-import pytest
+import os
+import shutil
+import tempfile
 
+import pytest
+import responses
+
+from archivy import app
+from archivy.extensions import get_db
 from archivy.models import DataObj
+
+
+@pytest.fixture
+def test_app():
+    """Instantiate the app for each test with its own temporary data directory
+
+    Each test using this fixture will use its own db.json and its own data
+    directory, and then delete them.
+    """
+    # create a temporary file to isolate the database for each test
+    app_dir = tempfile.mkdtemp()
+    app.config['APP_PATH'] = app_dir
+    data_dir = os.path.join(app_dir, "data")
+    os.mkdir(data_dir)
+
+    app.config['TESTING'] = True
+
+    # This setups a TinyDB instance, using the `app_dir` temporary
+    # directory defined above
+    # Required so that `flask.current_app` can be called in data.py and
+    # models.py
+    # See https://flask.palletsprojects.com/en/1.1.x/appcontext/ for more
+    # information.
+    with app.app_context():
+        _ = get_db()
+
+    yield app
+
+    # close and remove the temporary database
+    shutil.rmtree(app_dir)
+
+
+@pytest.fixture
+def client(test_app):
+    """ HTTP client for calling a test instance of the app"""
+    with test_app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def mocked_responses():
+    """Setup mock responses using the `responses` python package.
+
+    Using https://pypi.org/project/responses/, this fixture will mock out
+    HTTP calls made by the requests library.
+
+    For example,
+    >>> mocked_responses.add(responses.GET, "http://example.org", json={'key': 'val'})
+    >>> r = requests.get("http://example.org")
+    >>> print(r.json())
+    {'key': 'val'}
+    """
+    with responses.RequestsMock() as rsps:
+        # this ensure that all requests calls are mocked out
+        rsps.assert_all_requests_are_fired = True
+        yield rsps
+
 
 @pytest.fixture(scope="session")
 def note_fixture():

--- a/conftest.py
+++ b/conftest.py
@@ -66,10 +66,15 @@ def mocked_responses():
         yield rsps
 
 
-@pytest.fixture(scope="session")
-def note_fixture():
-    datapoints = {"type": "note", "title": "Test Note", "desc": "A note to test model functionality", "tags": ["testing", "archivy"], "path": ""}
+@pytest.fixture()
+def note_fixture(test_app):
+    datapoints = {
+        "type": "note", "title": "Test Note",
+        "desc": "A note to test model functionality",
+        "tags": ["testing", "archivy"], "path": ""
+    }
 
-    note = DataObj(**datapoints)
-    note.insert()
+    with test_app.app_context():
+        note = DataObj(**datapoints)
+        note.insert()
     return note

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,4 @@
+pytest==6.0.1
+
+# for mocking out requests HTTP calls
+responses==0.10.16

--- a/tests/integration/test_pocket.py
+++ b/tests/integration/test_pocket.py
@@ -19,8 +19,32 @@ def test_parse_pocket(test_app, client, mocked_responses, pocket_fixture):
     """)
 
 
+
     r: Flask.response_class = client.get('/parse_pocket?new=1')
     assert r.status_code == 302
 
     dataobjs = data.get_items()
     assert len(dataobjs.child_files) == 1
+
+
+def test_pocket_with_empty_title(test_app, client, pocket_fixture,
+                                 mocked_responses):
+    """Test the /pocket endpoint
+
+    HTTP calls to the pocket API are mocked out
+    """
+
+    # fake website
+    mocked_responses.add(responses.GET, "https://example.com/", body="""<html>
+        <head></head><body><p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit
+        </p></body></html>
+    """)
+
+    r: Flask.response_class = client.get('/parse_pocket?new=1')
+    assert r.status_code == 302
+
+    dataobjs = data.get_items()
+    assert len(dataobjs.child_files) == 1
+
+

--- a/tests/integration/test_pocket.py
+++ b/tests/integration/test_pocket.py
@@ -1,0 +1,26 @@
+import responses
+from flask import Flask
+
+from archivy import data
+from archivy.extensions import get_db
+
+
+def test_parse_pocket(test_app, client, mocked_responses, pocket_fixture):
+    """Test the /pocket endpoint
+
+    HTTP calls to the pocket API are mocked out
+    """
+
+    # fake website
+    mocked_responses.add(responses.GET, "https://example.com/", body="""<html>
+        <head><title>Example</title></head><body><p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit
+        </p></body></html>
+    """)
+
+
+    r: Flask.response_class = client.get('/parse_pocket?new=1')
+    assert r.status_code == 302
+
+    dataobjs = data.get_items()
+    assert len(dataobjs.child_files) == 1

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,22 +1,19 @@
 import frontmatter
-import pytest
 
 from archivy.extensions import get_max_id
 
 attributes = ["type", "title", "desc", "tags", "path", "id"]
 
-def test_new_note(note_fixture):
+
+def test_new_note(test_app, note_fixture):
     """
     Check that a new note is correctly saved into the filesystem
     with the right attributes and the right id.
     """
-    max_id = get_max_id()
-    assert note_fixture.id == max_id
-    
+    with test_app.app_context():
+        max_id = get_max_id()
+        assert note_fixture.id == max_id
+
     saved_file = frontmatter.load(note_fixture.fullpath)
     for attr in attributes:
         assert getattr(note_fixture, attr) == saved_file[attr]
-
-
-
-


### PR DESCRIPTION
Add integrations test for the pocket import, and several improvements for future testing.

New fixtures:

- `test_app` for setting up a temporary database for each test
- `client` for setting up  test client to test routes
- `mocked_responses` for setting up `responses`-based mocked HTTP calls (see below) 

Other changes:

 - add `requirements-tests.txt` for test dependencies (`pytest` and `responses`)
 - refactoring in `data.py` and `models.py` to allow changing the data directory at runtime
 - fix possible bug in `parse_pocket`

## Notes on mocking http calls
I'm using https://pypi.org/project/responses/ for mocking out requests calls in the pocket route. This can be confusing because the test client does not use `requests` (see https://werkzeug.palletsprojects.com/en/1.0.x/test/#werkzeug.test.Client). So, in my test, only the calls to `requests.get` and `requets.post` in the `/pocket` route are mocked. `client.post('/pocket', ...)` makes an actual call to the archivy route.

One possible fix would be to use another test client, wrapping requests, in integration tests.

In any case, feel free to suggest another way to mock external HTTP calls in tests.