### PR TITLE
add AUTHORS file for licensing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+* Uzay-G <uzgirit@gmail.com>
+* Srevin Saju <srevinsaju@sugarlabs.org>
+* Harsha Vardhan <34051768+HarshaVardhanJ@users.noreply.github.com>
+* Kwuang Tang <10319942+cktang88@users.noreply.github.com>
+* lhl <lhl@randomfoo.net>
+* Clément Schreiner <clement@mux.me>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Uzay-G
+Copyright (c) 2020 The authors, as per the AUTHORS file.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Not sure this is how you want to handle the license of contributions, this is just a suggestion. The list of authors has been generated with `git shortlog -n -s -e` on master.