### PR TITLE
improve error handling for elasticsearch

### DIFF
--- a/archivy/__init__.py
+++ b/archivy/__init__.py
@@ -1,32 +1,26 @@
-import elasticsearch
-import subprocess
 from pathlib import Path
 from threading import Thread
 
+import elasticsearch
 from flask import Flask
 
 from archivy import extensions
-from archivy.config import Config
 from archivy.check_changes import run_watcher
+from archivy.config import Config
 
 app = Flask(__name__)
 app.config.from_object(Config)
 
-# create dir that will hold data if it doesn"t already exist
+# create dir that will hold data if it doesn't already exist
 DIRNAME = app.config["APP_PATH"] + "/data/"
 Path(DIRNAME).mkdir(parents=True, exist_ok=True)
 
 if app.config["ELASTICSEARCH_ENABLED"]:
-    elastic_running = subprocess.run(
-        "service elasticsearch status",
-        shell=True,
-        stdout=subprocess.DEVNULL).returncode
-    if elastic_running != 0:
-        print("Enter password to enable elasticsearch")
-        subprocess.run("sudo service elasticsearch restart", shell=True)
+    es = extensions.elastic_client()
+
     try:
         print(
-            extensions.elastic_client().indices.create(
+            es.indices.create(
                 index=app.config["INDEX_NAME"],
                 body=app.config["ELASTIC_CONF"]))
     except elasticsearch.ElasticsearchException:

--- a/archivy/extensions.py
+++ b/archivy/extensions.py
@@ -1,7 +1,9 @@
-from tinydb import TinyDB, Query, operations
-from elasticsearch import Elasticsearch
-from archivy.config import Config
+import sys
 
+import elasticsearch
+from tinydb import TinyDB, Query, operations
+
+from archivy.config import Config
 
 DB = TinyDB(Config.APP_PATH + "/db.json")
 
@@ -19,5 +21,28 @@ def set_max_id(val):
 
 
 def elastic_client():
-    return Elasticsearch([Config.ELASTICSEARCH_URL]
-                         ) if Config.ELASTICSEARCH_ENABLED else None
+    if not Config.ELASTICSEARCH_ENABLED:
+        return None
+    es = elasticsearch.Elasticsearch([Config.ELASTICSEARCH_URL])
+    try:
+        health = es.cluster.health()
+    except elasticsearch.exceptions.ConnectionError:
+        sys.stderr.write(
+            "Elasticsearch does not seem to be running on {url}. Please start "
+            "it, for example with: sudo service elasticsearch restart".format(
+                url=Config.ELASTICSEARCH_URL
+            )
+        )
+        sys.stderr.write(
+            "You can disable Elasticsearch by setting the "
+            "ELASTICSEARCH_ENABLED environment variable to 0"
+        )
+        sys.exit(1)
+
+    if health["status"] not in ("yellow", "green"):
+        sys.stderr.write(
+            "WARNING: Elasticsearch reports that it is not working "
+            "properly. Search might not work. You can disable "
+            "Elasticsearch by setting ELASTICSEARCH_ENABLED to 0."
+        )
+    return es

--- a/archivy/extensions.py
+++ b/archivy/extensions.py
@@ -28,14 +28,13 @@ def elastic_client():
         health = es.cluster.health()
     except elasticsearch.exceptions.ConnectionError:
         sys.stderr.write(
-            "Elasticsearch does not seem to be running on {url}. Please start "
-            "it, for example with: sudo service elasticsearch restart".format(
-                url=Config.ELASTICSEARCH_URL
-            )
+            "Elasticsearch does not seem to be running on "
+            f"{Config.ELASTICSEARCH_URL}. Please start "
+            "it, for example with: sudo service elasticsearch restart\n"
         )
         sys.stderr.write(
             "You can disable Elasticsearch by setting the "
-            "ELASTICSEARCH_ENABLED environment variable to 0"
+            "ELASTICSEARCH_ENABLED environment variable to 0\n"
         )
         sys.exit(1)
 


### PR DESCRIPTION
 - use ES built-in health report instead of platform-dependant subprocess call
 - print user-friendly error messages instead of running subprocess commands
   with sudo