### PR TITLE
Security-related changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN apk update && apk add --no-cache \
     # Creating non-root user and group for running Archivy
     && addgroup -S -g 1000 archivy \
     && adduser -h /archivy -g "User account for running Archivy" \
-    -s /bin/nologin -S -D -G archivy -u 1000 archivy \
+    -s /sbin/nologin -S -D -G archivy -u 1000 archivy \
     # Creating directory in which Archivy's files will be stored
     # (If this directory isn't created, Archivy exits with a "permission denied" error)
     && mkdir -p /archivy/data \

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -63,5 +63,22 @@ commandTests:
     setup: [["entrypoint.sh", "sleep 1"]]
     command: "which"
     args: ["archivy"]
+    exitCode: 0
     expectedOutput: ["/usr/local/bin/archivy"]
-
+  - name: 'Check if running as non-root user'
+    setup: [["entrypoint.sh", "sleep 1"]]
+    command: "whoami"
+    expectedOutput: ["archivy"]
+    exitCode: 0
+  - name: 'Check group of non-root user'
+    setup: [["entrypoint.sh", "sleep 1"]]
+    command: "groups"
+    args: ["archivy"]
+    expectedOutput: ["archivy"]
+    exitCode: 0
+  - name: 'Check user details'
+    setup: [["entrypoint.sh", "sleep 1"]]
+    command: "getent"
+    args: ["passwd", "archivy"]
+    expectedOutput: ["archivy:x:1000:1000:(.*):/archivy:/sbin/nologin"]
+    exitCode: 0

--- a/docker-compose-with-elasticsearch.yml
+++ b/docker-compose-with-elasticsearch.yml
@@ -17,6 +17,8 @@ services:
       - archivy
     depends_on:
       - elasticsearch
+    cap_drop:
+      - ALL
     deploy:
       replicas: 1
       restart_policy:
@@ -38,6 +40,11 @@ services:
       archivy:
         aliases:
           - search
+    cap_drop:
+      - ALL
+    cap_add:
+      - SYS_CHROOT
+      - SETUID
     deploy:
       replicas: 1
       restart_policy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,13 @@ version: '3.8'
 services:
 
   archivy:
-    image: harshavardhanj/archivy:latest
+    image: harshavardhanj/archivy:0.0.7
     ports:
       - "5000:5000"
     volumes:
       - archivyData:/archivy/data
+    cap_drop:
+      - ALL
 
 volumes:
   archivyData:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 #
 #: Title        : entrypoint.sh
-#: Date         :	19-Aug-2020
-#: Author       :	"Harsha Vardhan J" <vardhanharshaj@gmail.com>
+#: Date         : 19-Aug-2020
 #: Version      : 0.1
 #: Description  : This file handles the startup of the 'Archivy' server
 #                 and other functions necessary for its startup such as


### PR DESCRIPTION
Changed the login shell of the `archivy` user in the container from
`/bin/nologin` to `/sbin/nologin` which the correct path.

Added tests to `container-structure-test.yaml` for checking the user
which is running inside the container, ther user's group, and their
login shell.

Denied linux capabilities to `archivy` and `elasticsearch` containers in
the compose files. For `elasticsearch`, only `SYS_CHROOT` and `SETUID`
capabilities are granted. By default, all capabilties are dropped first.
This prevents processes from having more than necessary capabilities
inside the container.

Changed image tag to `0.0.7` in `docker-compose.yml`.

Removed author's name from `entrypoint.sh`.