### PR TITLE
ADD: use builtin Elasticsearch highlighting for better quality of res…

### DIFF
--- a/archivy/config.py
+++ b/archivy/config.py
@@ -15,6 +15,9 @@ class Config(object):
     PANDOC_HIGHLIGHT_THEME = os.environ.get("PANDOC_THEME") or "kate"
     ELASTIC_CONF = {
         "settings": {
+            "highlight": {
+                "max_analyzed_offset": 100000000
+            },
             "analysis": {
                 "analyzer": {
                     "rebuilt_standard": {
@@ -32,7 +35,8 @@ class Config(object):
         },
         "mappings": {
             "properties": {
-                "title": {"type": "text", "analyzer": "rebuilt_standard"},
+                "title": {"type": "text", "analyzer": "rebuilt_standard",
+                                    "term_vector": "with_positions_offsets"},
                 "tags": {"type": "text", "analyzer": "rebuilt_standard"},
                 "body": {"type": "text", "analyzer": "rebuilt_standard"},
                 "desc": {"type": "text", "analyzer": "rebuilt_standard"}

--- a/archivy/config.py
+++ b/archivy/config.py
@@ -35,8 +35,11 @@ class Config(object):
         },
         "mappings": {
             "properties": {
-                "title": {"type": "text", "analyzer": "rebuilt_standard",
-                                    "term_vector": "with_positions_offsets"},
+                "title": {
+                    "type": "text",
+                    "analyzer": "rebuilt_standard",
+                    "term_vector": "with_positions_offsets"
+                },
                 "tags": {"type": "text", "analyzer": "rebuilt_standard"},
                 "body": {"type": "text", "analyzer": "rebuilt_standard"},
                 "desc": {"type": "text", "analyzer": "rebuilt_standard"}

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -34,9 +34,9 @@ def query_index(index, query):
                     "analyzer": "rebuilt_standard"
                 }
             },
-            "highlight" : {
-                "fields" : {
-                    "content" : {
+            "highlight": {
+                "fields": {
+                    "content": {
                         "pre_tags": "<span style='background-color: #f6efa6'>",
                         "post_tags": "</span>",
                         "boundary_max_scan": 200,
@@ -44,22 +44,24 @@ def query_index(index, query):
                     }
                 }
             }
-        }           
+        } 
     )
 
     hits = []
     for hit in search["hits"]["hits"]:
         formatted_hit = {"id": hit["_id"], "title": hit["_source"]["title"], "highlight": []}
         if "highlight" in hit:
-            # FIXME: find a way to make this less hacky and yet still conserve logical separations
+            # FIXME: find a way to make this less hacky and
+            # yet still conserve logical separations
             # hack to make pandoc faster by converting highlights in one go
             # join highlights into string with symbolic separator
             SEPARATOR = "~~~~~~~~~~~~~~~~~~|~~~~~~~~~~~~~~~~~~"
             concatenated_highlight = SEPARATOR.join(
                     [highlight for highlight in hit["highlight"]["content"]])
             # re split highlights
-            formatted_hit["highlight"] = convert_text(concatenated_highlight, "html", format="md")
-                                            .split(SEPARATOR)
+            formatted_hit["highlight"] = convert_text(concatenated_highlight,
+                                                      "html",
+                                                      format="md").split(SEPARATOR)
 
         hits.append(formatted_hit)
 

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -44,7 +44,7 @@ def query_index(index, query):
                     }
                 }
             }
-        } 
+        }
     )
 
     hits = []

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -50,10 +50,16 @@ def query_index(index, query):
     hits = []
     for hit in search["hits"]["hits"]:
         formatted_hit = {"id": hit["_id"], "title": hit["_source"]["title"], "highlight": []}
-
         if "highlight" in hit:
-            for highlight in hit["highlight"]["content"]:
-                formatted_hit["highlight"].append(convert_text(highlight, "html", format="md"))
+            # FIXME: find a way to make this less hacky and yet still conserve logical separations
+            # hack to make pandoc faster by converting highlights in one go
+            # join highlights into string with symbolic separator
+            SEPARATOR = "~~~~~~~~~~~~~~~~~~|~~~~~~~~~~~~~~~~~~"
+            concatenated_highlight = SEPARATOR.join(
+                    [highlight for highlight in hit["highlight"]["content"]])
+            # re split highlights
+            formatted_hit["highlight"] = convert_text(concatenated_highlight, "html", format="md")
+                                            .split(SEPARATOR)
 
         hits.append(formatted_hit)
 

--- a/archivy/search.py
+++ b/archivy/search.py
@@ -1,3 +1,5 @@
+from pypandoc import convert_text
+
 from archivy.extensions import get_elastic_client
 
 
@@ -29,7 +31,30 @@ def query_index(index, query):
                 "multi_match": {
                     "query": query,
                     "fields": ["*"],
-                    "analyzer": "rebuilt_standard"}}},
+                    "analyzer": "rebuilt_standard"
+                }
+            },
+            "highlight" : {
+                "fields" : {
+                    "content" : {
+                        "pre_tags": "<span style='background-color: #f6efa6'>",
+                        "post_tags": "</span>",
+                        "boundary_max_scan": 200,
+                        "fragment_size": 0
+                    }
+                }
+            }
+        }           
     )
 
-    return search["hits"]["hits"]
+    hits = []
+    for hit in search["hits"]["hits"]:
+        formatted_hit = {"id": hit["_id"], "title": hit["_source"]["title"], "highlight": []}
+
+        if "highlight" in hit:
+            for highlight in hit["highlight"]["content"]:
+                formatted_hit["highlight"].append(convert_text(highlight, "html", format="md"))
+
+        hits.append(formatted_hit)
+
+    return hits

--- a/archivy/templates/home.html
+++ b/archivy/templates/home.html
@@ -24,45 +24,38 @@
 	// search functionality
 	{% if search_enabled %}	
 		var md = window.markdownit();
-		function appendHit(hit, hidden, query) {
+		function appendHit(hit,  query) {
 			let hitsDiv = document.getElementById("searchHits");
 			let hitLi = document.createElement("li");
-			let p = document.createElement("p"), a = document.createElement("a"), hitText = '';
-			// match certain semantic elements
-			// refactor to instead ignore <img>
-			let paragraphs = md.render(hit['_source']['content']).replace(/(\r\n\t|\n|\r\t)/gm,"").match(/(<(p|li|blockquote|strong|b).*>.*<\/(p|li|blockquote|strong|b)>)/mg);
-			for(let i = 0; paragraphs && i < paragraphs.length; i++)
+			let body = document.createElement("div");
+			if ("highlight" in hit)
 			{
-				if (paragraphs[i].toUpperCase().includes(query.toUpperCase())) {
-					hitText += `${paragraphs[i]}`;
+				for(let i = 0; i < hit["highlight"].length; i++)
+				{
+					body.innerHTML += hit["highlight"][i];	
 				}
 			}
-			hitText = hitText.replace(query, "<span style='background-color: #f6efa6'>" + query + "</span>");
-			p.innerHTML = hitText, a.textContent = hit['_source']['title'], a.href = `/dataobj/${hit['_id']}`;
+			let p = document.createElement("p"), a = document.createElement("a"), hitText = '';
+			p.innerHTML = hitText, a.textContent = hit["title"], a.href = `/dataobj/${hit['id']}`;
 			hitLi.append(a);
 			hitLi.append(p);
-			if (hidden)
-			{
-				hitLi.classList = "hidden";
-			}
+			hitLi.append(body);
 			hitsDiv.appendChild(hitLi);
 		}
 		let input = document.getElementById("searchBar");
 		input.addEventListener('input', async function(e) {
+			let query = input.value;
 			if (input.value !== "")
 			{
 				let searchQuery = await fetch(`${SCRIPT_ROOT}/search?query=${input.value}`, {
 					"method": "GET"
 				});
-				if (searchQuery.ok) {	
+				if (searchQuery.ok && query == input.value) {	
 					let data = await searchQuery.json(), i = 0;
-					console.log(data);
 					document.getElementById("searchHits").innerHTML = "";
 					data.forEach(function(hit)
 					{
-						let hidden = i > 4;
-						appendHit(hit, hidden, input.value);
-						i++;
+						appendHit(hit, input.value);
 					})
 				}
 			}


### PR DESCRIPTION
This PR enforces the use of the built-in Elasticsearch highlighter to provide a MUCH better quality of search results.

Unfortunately I think the fact that I am rendering the markdown posts to html with pypandoc is causing things to work slightly slower.

Potential way to fix this:

- Send HTML instead of markdown to ES - would mean converting to html on each edit.

If you have any ideas for performance please comment - and see below for the improvements:

![random](https://user-images.githubusercontent.com/52892257/92163265-abb91e00-ee33-11ea-8e08-a5fa1e53d14d.gif)
