### PR TITLE
Fixed errors in `build-docker-on-push-master.yml` and `build-docker-on-release.yml`.

### DIFF
--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -113,7 +113,7 @@ jobs:
   dockerBuildPush:
     name: Build and push image with release version tag
     runs-on: ubuntu-latest
-    needs: [ContainerTestScan]
+    needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v1

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -7,12 +7,6 @@ on:
     paths:
       - 'archivy/**'
       - '.github/workflows/build-on-push-master.yml'
-  pull_request:
-    branches:
-      - 'master'
-    paths:
-      - 'archivy/**'
-      - '.github/workflows/build-on-push-master.yml'
 
 jobs:
   BuildPushUntested:
@@ -20,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -66,7 +60,7 @@ jobs:
     needs: [BuildPushUntested]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -116,7 +110,7 @@ jobs:
     needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -101,7 +101,7 @@ jobs:
   dockerBuildPush:
     name: Build and push image with release version tag
     runs-on: ubuntu-latest
-    needs: [ContainerTestScan]
+    needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v1

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -55,7 +55,7 @@ jobs:
     needs: [BuildPushUntested]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -104,7 +104,7 @@ jobs:
     needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 


### PR DESCRIPTION
Have fixed the error in `build-docker-on-push-master.yml` and `build-docker-on-release.yml`, which was that the job `dockerBuildPush` was depending on the job `ContainerTestScan`. The name of this job was actually `ContainerTestAndScan`.

Have removed the `trigger on pull request to master branch` condition in `build-docker-on-push-master.yml` as it would result in images built with unmerged and unapproved code.

Also changed the version of the `checkout` action to `v2` in both files.