### PR TITLE
Fixed errors in docker-related actions files

### DIFF
--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           docker buildx build \
             --output type=image,name=${{ env.docker_image }},push=true \
-            --build-arg BUILD_DATE "${{ env.timestamp }}" --build-arg VCS_REF "${{ env.hash }}" \
+            --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.tag_name }}" \
             --tag "${{ env.docker_image }}:untested-${{ env.hash }}" \
             --file ./Dockerfile .

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -113,7 +113,7 @@ jobs:
   dockerBuildPush:
     name: Build and push image with release version tag
     runs-on: ubuntu-latest
-    needs: [ContainerTestScan]
+    needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v1

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -7,12 +7,6 @@ on:
     paths:
       - 'archivy/**'
       - '.github/workflows/build-on-push-master.yml'
-  pull_request:
-    branches:
-      - 'master'
-    paths:
-      - 'archivy/**'
-      - '.github/workflows/build-on-push-master.yml'
 
 jobs:
   BuildPushUntested:
@@ -20,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -66,7 +60,7 @@ jobs:
     needs: [BuildPushUntested]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -116,7 +110,7 @@ jobs:
     needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -44,8 +44,8 @@ jobs:
         if: success()
         run: |
           docker buildx build \
-            --output type=image,name=${{ env.docker_image }},push=true --build-arg VERSION "${{ env.version }}" \
-            --build-arg BUILD_DATE "${{ env.timestamp }}" --build-arg VCS_REF "${{ env.hash }}" \
+            --output type=image,name=${{ env.docker_image }},push=true --build-arg VERSION=${{ env.version }} \
+            --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.version }}" \
             --tag "${{ env.docker_image }}:untested-${{ env.hash }}" --file ./Dockerfile .
 
@@ -154,7 +154,7 @@ jobs:
         run: |
           docker buildx build \
             --output type=image,name=${{ env.docker_image }},push=true \
-            --platform ${{ env.docker_platforms }} --build-arg VERSION "${{ env.version }}" \
+            --platform ${{ env.docker_platforms }} --build-arg VERSION=${{ env.version }} \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:${{ env.version }}" \
             --tag "${{ env.docker_image }}:${{ env.major_version }}.${{ env.minor_version }}" \

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -101,7 +101,7 @@ jobs:
   dockerBuildPush:
     name: Build and push image with release version tag
     runs-on: ubuntu-latest
-    needs: [ContainerTestScan]
+    needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v1

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -55,7 +55,7 @@ jobs:
     needs: [BuildPushUntested]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -104,7 +104,7 @@ jobs:
     needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 


### PR DESCRIPTION
In files `build-docker-on-push-master.yml` and `build-docker-on-release.yml`, the `--build-arg` value needs to be in
the form of `KEY=VALUE`. Instead, it was `KEY VALUE`. Have fixed this.