### PR TITLE
Fixed errors in Actions files

### DIFF
--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           docker buildx build \
             --output type=image,name=${{ env.docker_image }},push=true \
-            --build-arg BUILD_DATE "${{ env.timestamp }}" --build-arg VCS_REF "${{ env.hash }}" \
+            --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.tag_name }}" \
             --tag "${{ env.docker_image }}:untested-${{ env.hash }}" \
             --file ./Dockerfile .

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -29,10 +29,10 @@ jobs:
 
       - name: Set up Docker Buildx
         if: success()
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1.0.2
         with:
-          buildx_version: latest
-          qemu_version: latest
+          install: true
+          version: latest
 
       - name: Docker login
         if: success()
@@ -47,7 +47,7 @@ jobs:
       - name: Run buildx to push untested image
         if: success()
         run: |
-          docker buildx build \
+          docker build \
             --output type=image,name=${{ env.docker_image }},push=true \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.tag_name }}" \
@@ -122,20 +122,13 @@ jobs:
           echo ::set-env name=image_tag::source
           echo ::set-env name=docker_username::uzayg
           echo ::set-env name=docker_image::docker.io/uzayg/archivy
-          echo ::set-env name=docker_platforms::linux/amd64
-          #echo ::set-env name=docker_platforms::linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/s390x
 
       - name: Set up Docker Buildx
         if: success()
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        uses: docker/setup-buildx-action@v1.0.2
         with:
-          buildx_version: latest
-          qemu_version: latest
-
-      - name: Print available platforms for buildx
-        if: success()
-        run: echo ${{ steps.buildx.outputs.platforms }}
+          install: true
+          version: latest
 
       - name: Docker login
         if: success()
@@ -150,9 +143,8 @@ jobs:
       - name: Build and push with Docker Buildx
         if: success()
         run: |
-          docker buildx build \
+          docker build \
             --output type=image,name=${{ env.docker_image }},push=true \
-            --platform ${{ env.docker_platforms }} \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:${{ env.tag_name }}" \
             --tag "${{ env.docker_image }}:${{ env.hash }}" \

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -113,7 +113,7 @@ jobs:
   dockerBuildPush:
     name: Build and push image with release version tag
     runs-on: ubuntu-latest
-    needs: [ContainerTestScan]
+    needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v1

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -52,7 +52,7 @@ jobs:
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.tag_name }}" \
             --tag "${{ env.docker_image }}:untested-${{ env.hash }}" \
-            --file ./Dockerfile .
+            --file ./Dockerfile.source .
 
   ContainerTestAndScan:
     name: Test image with 'untested' tag using Hadolint, container-structure-test, Trivy, and Anchore
@@ -148,7 +148,7 @@ jobs:
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:${{ env.tag_name }}" \
             --tag "${{ env.docker_image }}:${{ env.hash }}" \
-            --file ./Dockerfile .
+            --file ./Dockerfile.source .
 
   deleteUntestedImage:
     name: Delete images with the 'untested' tag

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -7,12 +7,6 @@ on:
     paths:
       - 'archivy/**'
       - '.github/workflows/build-on-push-master.yml'
-  pull_request:
-    branches:
-      - 'master'
-    paths:
-      - 'archivy/**'
-      - '.github/workflows/build-on-push-master.yml'
 
 jobs:
   BuildPushUntested:
@@ -20,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -66,7 +60,7 @@ jobs:
     needs: [BuildPushUntested]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -116,7 +110,7 @@ jobs:
     needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 

--- a/.github/workflows/build-docker-on-push-master.yml
+++ b/.github/workflows/build-docker-on-push-master.yml
@@ -50,7 +50,7 @@ jobs:
           docker build \
             --output type=image,name=${{ env.docker_image }},push=true \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
-            --tag "${{ env.docker_image }}:untested-${{ env.tag_name }}" \
+            --tag "${{ env.docker_image }}:untested-${{ env.image_tag }}" \
             --tag "${{ env.docker_image }}:untested-${{ env.hash }}" \
             --file ./Dockerfile.source .
 
@@ -146,7 +146,7 @@ jobs:
           docker build \
             --output type=image,name=${{ env.docker_image }},push=true \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
-            --tag "${{ env.docker_image }}:${{ env.tag_name }}" \
+            --tag "${{ env.docker_image }}:${{ env.image_tag }}" \
             --tag "${{ env.docker_image }}:${{ env.hash }}" \
             --file ./Dockerfile.source .
 

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -44,8 +44,8 @@ jobs:
         if: success()
         run: |
           docker buildx build \
-            --output type=image,name=${{ env.docker_image }},push=true --build-arg VERSION "${{ env.version }}" \
-            --build-arg BUILD_DATE "${{ env.timestamp }}" --build-arg VCS_REF "${{ env.hash }}" \
+            --output type=image,name=${{ env.docker_image }},push=true --build-arg VERSION=${{ env.version }} \
+            --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.version }}" \
             --tag "${{ env.docker_image }}:untested-${{ env.hash }}" --file ./Dockerfile .
 
@@ -154,7 +154,7 @@ jobs:
         run: |
           docker buildx build \
             --output type=image,name=${{ env.docker_image }},push=true \
-            --platform ${{ env.docker_platforms }} --build-arg VERSION "${{ env.version }}" \
+            --platform ${{ env.docker_platforms }} --build-arg VERSION=${{ env.version }} \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:${{ env.version }}" \
             --tag "${{ env.docker_image }}:${{ env.major_version }}.${{ env.minor_version }}" \

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -1,6 +1,8 @@
 name: Building, Testing, and Pushing Archivy Container Image On Version Release
 
 on:
+  push:
+    tags: v[0-9]+.[0-9]+.[0-9]+
   release:
     types:
       - published

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Set up Docker Buildx
         if: success()
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1.0.2
         with:
-          buildx_version: latest
-          qemu_version: latest
+          install: true
+          version: latest
 
       - name: Docker login
         if: success()
@@ -43,7 +43,7 @@ jobs:
       - name: Run buildx to push untested image
         if: success()
         run: |
-          docker buildx build \
+          docker build \
             --output type=image,name=${{ env.docker_image }},push=true --build-arg VERSION=${{ env.version }} \
             --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:untested-${{ env.version }}" \
@@ -118,20 +118,13 @@ jobs:
           echo ::set-env name=minor_version::$(echo ${GITHUB_REF/refs\/tags\//} | awk -F'.' '{print $2}')
           echo ::set-env name=docker_username::uzayg
           echo ::set-env name=docker_image::docker.io/uzayg/archivy
-          echo ::set-env name=docker_platforms::linux/amd64
-          #echo ::set-env name=docker_platforms::linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/s390x
 
       - name: Set up Docker Buildx
         if: success()
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        uses: docker/setup-buildx-action@v1.0.2
         with:
-          buildx_version: latest
-          qemu_version: latest
-
-      - name: Print available platforms for buildx
-        if: success()
-        run: echo ${{ steps.buildx.outputs.platforms }}
+          install: true
+          version: latest
 
       - name: Docker login
         if: success()
@@ -152,10 +145,10 @@ jobs:
       - name: Build and push with Docker Buildx
         if: success()
         run: |
-          docker buildx build \
+          docker build \
             --output type=image,name=${{ env.docker_image }},push=true \
-            --platform ${{ env.docker_platforms }} --build-arg VERSION=${{ env.version }} \
-            --build-arg BUILD_DATE=${{ env.timestamp }} --build-arg VCS_REF=${{ env.hash }} \
+            --build-arg VERSION=${{ env.version }} --build-arg BUILD_DATE=${{ env.timestamp }} \
+            --build-arg VCS_REF=${{ env.hash }} \
             --tag "${{ env.docker_image }}:${{ env.version }}" \
             --tag "${{ env.docker_image }}:${{ env.major_version }}.${{ env.minor_version }}" \
             --tag "${{ env.docker_image }}:${{ env.hash }}" \

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -101,7 +101,7 @@ jobs:
   dockerBuildPush:
     name: Build and push image with release version tag
     runs-on: ubuntu-latest
-    needs: [ContainerTestScan]
+    needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
         uses: actions/checkout@v1

--- a/.github/workflows/build-docker-on-release.yml
+++ b/.github/workflows/build-docker-on-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -55,7 +55,7 @@ jobs:
     needs: [BuildPushUntested]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 
@@ -104,7 +104,7 @@ jobs:
     needs: [ContainerTestAndScan]
     steps:
       - name: Checkout files from repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: docker
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt', encoding='utf-8') as f:
 
 setuptools.setup(
     name="archivy",
-    version="0.4.1",
+    version="0.5.0",
     author="Uzay-G",
     author_email="uzgirit@gmail.com",
     description=(


### PR DESCRIPTION
In `build-docker-on-push-master.yml`, the job `buildPushUntested` was referring to a variable `tag_name` instead of `image_tag`, which led to images being pushed with the tag `untested-`. This has been fixed.

In `build-docker-on-release.yml`, the conditions which trigger the run were `on publish of release`. This wasn't getting triggered when tags were being pushed, which is needed. Have added a condition `on push of tags`.

Also, there's an error in the linting step(`Hadolint`). This will be fixed in the `docker` branch.